### PR TITLE
Updated bridge link on HowTo

### DIFF
--- a/docs/howto_bridge.md
+++ b/docs/howto_bridge.md
@@ -20,7 +20,7 @@ To perform XCM transfers for one of the assets listed above, you can use [Karura
 </div>
 
 ### Step 1: Navigate to the Karura Bridge Page
-[https://apps.karura.network/bridge](https://apps.karura.network/bridge)
+[https://apps.karura.network/bridge](https://apps.karura.network/bridge?fromChainName=kusama&toChainName=basilisk)
 
 ### Step 2: Connect to Your Account
 


### PR DESCRIPTION
updated the bridge link on the HowTo so that it pre-selects Kusama and Basilisk networks